### PR TITLE
Export hslToRgb() function

### DIFF
--- a/converter.js
+++ b/converter.js
@@ -50,3 +50,5 @@ var hslToRgb = function(hue, saturation, lightness){
   return [Math.round(red * 255), Math.round(green * 255), Math.round(blue * 255)];
 
 };
+
+module.exports = hslToRgb;


### PR DESCRIPTION
I wanted to use this modue but no the function was not being exported via `module.exports`. If you merge this please publish a new version to npm.