### PR TITLE
Patch to work with npm

### DIFF
--- a/converter.js
+++ b/converter.js
@@ -50,3 +50,5 @@ var hslToRgb = function(hue, saturation, lightness){
   return [Math.round(red * 255), Math.round(green * 255), Math.round(blue * 255)];
 
 };
+
+module.exports = hslToRgb;


### PR DESCRIPTION
Fixes library so example on npm (here: https://www.npmjs.com/package/hsl-to-rgb) works:

```js
var converter = require('hsl-to-rgb');
 
var slateBlue = converter(223, 0.44, 0.56);
 
console.log(slateBlue);
// logs [86, 115, 189]
```

Check this out too: https://github.com/systemjs/systemjs/blob/master/docs/module-formats.md